### PR TITLE
Acq help updates

### DIFF
--- a/docs/reference/gettingstartedexample/gse-acq-help.md
+++ b/docs/reference/gettingstartedexample/gse-acq-help.md
@@ -11,6 +11,7 @@ Refer to this document to understand the elements of the getting started example
 - **RIO Device** - Resource name of the PXIe-148X device to be used.
 - **Bitfile Path** - Full path to an FPGA bitfile (.lvbitx) to be downloaded and run on the FPGA of the PXIe-148X. Depending on your PXIe-148X module, use the following bitfiles.
   #### Table of PXIe-148X Acquisition Bitfiles
+
   | **Interface Module**     | **Bitfile**                           |
   |--------------------------|---------------------------------------|
   | PXIe-1486 (8 In)         | PXIe_1486_8\_In.lvbitx                |
@@ -32,6 +33,7 @@ Refer to this document to understand the elements of the getting started example
 - **CSI-2 Data Source** - Selects the CSI-2 data source type. "Corrected" returns the received data after correcting for single-bit transmission errors. "Raw" returns the received data as is. 
 - **Configuration Script** - Full path to a script file used to configure the deserializer.
   #### Table of PXIe-148X Acquisition Scripts
+
   | **Interface Module**               | **Configuration Script**                                                   |
   |------------------------------------|----------------------------------------------------------------------------|
   | PXIe-1486 (8 In)                   | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
@@ -130,9 +132,12 @@ Refer to this document to understand the elements of the getting started example
 
 ### Serial Channel Packets Tab (First or Second)
 > The getting started example displays packet data for the first two channels specified in the Channel Configurations array at the completion of the acquisition. If other packet data is desired, either re-order the active channels in the configuration array on the Serial Channel tab or use the TDMS File Viewer utility.
+
+> Note: If displaying a large number of packets, the VI may appear unresponsive for a period of time after the acquisition completes while the packet data is processed.
+
 - **Acquired Packets** - Displays the LLP packet information for the number of packets specified in the **Logged Packets to Display** control starting at the first logged packet.
-    > Note: If displaying a large number of packets, the VI may appear unresponsive for a period of time after the acquisition completes while the packet data is processed.
   #### Table of Descriptions for Acquired Packets Columns
+
   | Column | Description |
   | ------ | ----------- |
   | Index | The order packets were received. |

--- a/docs/reference/gettingstartedexample/gse-acq-help.md
+++ b/docs/reference/gettingstartedexample/gse-acq-help.md
@@ -122,10 +122,10 @@ Refer to this document to understand the elements of the getting started example
 
 ### Display Channel Tab (First or Second)
 > By default, the getting started example allows displaying images for two serial input channels, which can be viewed by clicking on the First Display Channel and Second Display Channel tabs while the acquisition is running.
+
 - **Image Display** - Displays the most recently acquired frame of the corresponding display channel. Interactive pan and zoom capabilities are provided by the buttons in the upper left corner of the image display. The text field below the image shows the image size, zoom factor, image type, pixel value and coordinate information.
 - **Serial Channel** - Selects the serial channel number for the image data to be displayed if more than two serial input channels are active.
     > This control may be modified while the VI is running.
-
 - **Source Rate (fps)** - Displays the frame rate in frames per second at which the image data is being received.
 - **Update Rate (fps)** - Displays the rate in frames per second at which the image display indicator is being updated.
     > Note: If multiple frames have arrived since the last update, only the most recent frame is displayed and the others are skipped in an attempt to keep up with the acquisition.
@@ -158,11 +158,13 @@ Refer to this document to understand the elements of the getting started example
 
 ### I2C Timestamps Tab
 > Note: To display I2C timestamp data, **Log I2C to Disk** must be enabled on the Resource tab and desired timestamp IDs must be added to the **timestamp filter** array on the I2C tab. The I2C timestamp data displayed is read from the User_Timestamps.tdms file and filtered to display only timestamp IDs included in the **timestamp filter** array.
+
 - **I2C Timestamps** - Displays I2C timestamp information for all I2C IDs in the **timestamp filter** array on the I2C tab. I2C timestamps begin logging immediately after the FPGA bitfile is downloaded and include timestamp data prior to the start of the LLP packet data acquisition, such as I2C traffic from the configuration script.
     > The **I2C Timestamps** display is updated after the acquisition completes.
 
 ### GPIO Timestamps Tab
 > Note: To display GPIO digital waveforms, **Log GPIO to Disk** must be enabled on the Resource tab and desired GPIO lines must be added to the **GPIO to Display** array on the GPIO tab. The GPIO timestamp data displayed is read from the GPIO_Timestamps.tdms file and filtered to display only GPIO lines included in the **GPIO to Display** array.
+
 - **GPIO Timestamps Waveform** - Displays a digital waveform for each GPIO line included in the **GPIO to Display** array on the GPIO tab. GPIO timestamps begin logging immediately after the FPGA bitfile is downloaded and include timestamp data prior to the start of the LLP packet data acquisition, such as toggles created from a reset.
     > The **GPIO Timestamps Waveform** display is updated after the acquisition completes.
 - **Error Parsing GPIO Timestamps** - Indicates if an error occurred while creating the digital waveform in the "Build GPIO Waveform.vi" SubVI.
@@ -170,7 +172,6 @@ Refer to this document to understand the elements of the getting started example
 ## General
 - **Stop Acquisition** - Creates a manual stop trigger for the acquisition. Clicking this button will cause all processing loops (Display, I2C, GPIO, monitoring, and LLP acquisition) to stop and the VI to stop running.
     > This control may be set while the VI is running.
-
 - **Acquisition In Progress** - Indicates that the configuration is complete and the acquisition has started.
 - **Acquisition Duration (s)** - Displays the duration in seconds between the start of the acquisition and the time a stop trigger is received.
     > Note: **Acquisition Duration (s)** does not include configuration time or post processing time.

--- a/docs/reference/gettingstartedexample/gse-acq-help.md
+++ b/docs/reference/gettingstartedexample/gse-acq-help.md
@@ -6,6 +6,7 @@ Refer to this document to understand the elements of the getting started example
 > Note: This document references the example included with the NI-FlexRIO 22Q3 driver. Examples included in newer releases of the driver should be appliable.
 
 ## Configuration Settings
+
 ### Resource Tab
 - **RIO Device** - Resource name of the PXIe-148X device to be used.
 - **Bitfile Path** - Full path to an FPGA bitfile (.lvbitx) to be downloaded and run on the FPGA of the PXIe-148X. Depending on your PXIe-148X module, use the following bitfiles.
@@ -26,23 +27,26 @@ Refer to this document to understand the elements of the getting started example
     > Note: Specifying a large number of packets to display may cause the VI to appear unresponsive for a period of time after the acquisition completes while the packet data is processed.
 - **Log I2C to Disk** - Enable to log I2C timestamps to a TDMS file.
 - **Log GPIO to Disk** - Enable to log GPIO timestamps to a TDMS file.
+
 ### Serial Channel Tab
 - **CSI-2 Data Source** - Selects the CSI-2 data source type. "Corrected" returns the received data after correcting for single-bit transmission errors. "Raw" returns the received data as is. 
 - **Configuration Script** - Full path to a script file used to configure the deserializer.
-  #### Table of PXIe-148X Acquisition Scripts
+
+    #### Table of PXIe-148X Acquisition Scripts
     
-  | **Interface Module**               | **Configuration Script**                                                   |
-  |------------------------------------|----------------------------------------------------------------------------|
-  | PXIe-1486 (8 In)                   | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
-  | PXIe-1486 (4 In 4 Out)             | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
-  | PXIe-1487 (8 In) Even Channels     | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_A.cpp         |
-  | PXIe-1487 (8 In) Odd Channels      | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_B.cpp         |
-  | PXIe-1487 (8 In) Adjacent Channels | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID01_RevSplit.cpp |
-  | PXIe-1487 (4 In 4 Out)             | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_B.cpp         |
+    | **Interface Module**               | **Configuration Script**                                                   |
+    |------------------------------------|----------------------------------------------------------------------------|
+    | PXIe-1486 (8 In)                   | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
+    | PXIe-1486 (4 In 4 Out)             | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
+    | PXIe-1487 (8 In) Even Channels     | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_A.cpp         |
+    | PXIe-1487 (8 In) Odd Channels      | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_B.cpp         |
+    | PXIe-1487 (8 In) Adjacent Channels | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID01_RevSplit.cpp |
+    | PXIe-1487 (4 In 4 Out)             | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_B.cpp         |
 - **Channel Configurations** - Array of active serial channels and display parameters for each channel.
     - **Serial Channel** - String representing the active serial channel in the format "SI" for Serial Input or "SO" for Serial Output followed by the channel number (i.e. "SI0")
     - **FPGA Display Parameters** - Parameters that determine what packet data the FPGA will send to the host for display.
-            > Note: Display parameters only affect the image on the display channel, not any data logged to disk.
+        > Note: Display parameters only affect the image on the display channel, not any data logged to disk.
+        
         - **virtual channel** - Number representing a Virtual Channel Identifier.
             > Virtual channel identifiers designate separate logical channels for data flows interleaved in the data path.
         - **payload data type** - Data type of the LLP packet payload for long packets.
@@ -69,6 +73,7 @@ Refer to this document to understand the elements of the getting started example
             - **Red Gain** - The gain to be applied to the red pixels in a Bayer-encoded image. The valid range for this parameter is 0 to 3.999.
             - **Green Gain** - The gain to be applied to the green pixels in a Bayer-encoded image. The valid range for this parameter is 0 to 3.999.
             - **Blue Gain** - The gain to be applied to the blue pixels in a Bayer-encoded image. The valid range for this parameter is 0 to 3.999.
+
 ### Acquisition Tab
 - **Acquisition Duration (s)** - The acquisition duration in seconds. The duration specifies the time from the start of the acquisition to the assertion of a stop trigger.
     > Note: If continuous acquisition is enabled, the acquisition duration is ignored.
@@ -85,6 +90,7 @@ Refer to this document to understand the elements of the getting started example
 - **Invert Data Type Filter** - If enabled, packet data types included in the data type filter array are the only packets acquired and all other packets are ignored. If disabled, packet data types included in the data type filter array are ignored and all other packet data types are acquired.
 - **Virtual Channel Filter** - Specifies virtual channel packets to ignore (filter out) during the acquisition.
 - **Invert Virtual Channel Filter** - If enabled, packets with a virtual channel included in the virtual channel filter array are the only virtual channel packets acquired and all other virtual channel packets are ignored. If disabled, packets with a virtual channel included in the virtual channel filter array are ignored and all other virtual channel packets are acquired.
+
 ### Board Tab
 - **Power Over Coax Source** - The source used to provide power over coax on active serial input channels.
     
@@ -111,6 +117,7 @@ Refer to this document to understand the elements of the getting started example
     > **GPIO Bank Read** line values are updated continuously throughout the acquisition.
 
 ## Data Output
+
 ### Display Channel Tab (First or Second)
 > By default, the getting started example allows displaying images for two serial input channels, which can be viewed by clicking on the First Display Channel and Second Display Channel tabs while the acquisition is running.
 - **Image Display** - Displays the most recently acquired frame of the corresponding display channel. Interactive pan and zoom capabilities are provided by the buttons in the upper left corner of the image display. The text field below the image shows the image size, zoom factor, image type, pixel value and coordinate information.
@@ -120,32 +127,37 @@ Refer to this document to understand the elements of the getting started example
 - **Source Rate (fps)** - Displays the frame rate in frames per second at which the image data is being received.
 - **Update Rate (fps)** - Displays the rate in frames per second at which the image display indicator is being updated.
     > Note: If multiple frames have arrived since the last update, only the most recent frame is displayed and the others are skipped in an attempt to keep up with the acquisition.
+
 ### Serial Channel Packets Tab (First or Second)
 > The getting started example displays packet data for the first two channels specified in the Channel Configurations array at the completion of the acquisition. If other packet data is desired, either re-order the active channels in the configuration array on the Serial Channel tab or use the TDMS File Viewer utility.
 - **Acquired Packets** - Displays the LLP packet information for the number of packets specified in the **Logged Packets to Display** control starting at the first logged packet.
     > Note: If displaying a large number of packets, the VI may appear unresponsive for a period of time after the acquisition completes while the packet data is processed.
-    
-   | Column | Description |
-   | ------ | ----------- |
-   | Index | The order packets were received. |
-   | Timestamp (s) | The time in seconds when the packet was received. Timestamps are relative to a time immediately after the FPGA bitfile is downloaded and run, not the start of the acquisition. This allows capturing I2C and GPIO timestamps during configuration before the acquisition starts. |
-   | Source | The unique timestamp identifier that indicates the source serial channel for the LLP packet. |
-   | Data Type | The type of data contained in the LLP packet (i.e. Frame Start, Frame End, RAW types, YUV types, RGB types, etc.). |
-   | Virtual Channel | A number representing a virtual channel identifier. Virtual channel identifiers designate separate logical channels for data flows interleaved in the data path. |
-   | ECC | The Error Correction Code (ECC) detects bit errors in the header. |
-   | Word Count | The number of bytes in a long packet (i.e. payload size or bytes per line) and does not include the header or footer bytes. |
-   | Line Count | The Line Count value comes from the Word Count field in Line Start and Line End packets, which are optional. |
-   | Frame Count | The Frame Count value comes from the Word Count field in Frame Start and Frame End packets, which are mandatory, but there are no requirements on what the value is set to. |
-   | CRC | The Cyclic Redundancy Check (CRC) comes from the footer of every long packet and is used to determine the validity of the long packet payload data. |
+  
+    #### Table of Descriptions for Acquired Packets Columns
+
+    | Column | Description |
+    | ------ | ----------- |
+    | Index | The order packets were received. |
+    | Timestamp (s) | The time in seconds when the packet was received. Timestamps are relative to a time immediately after the FPGA bitfile is downloaded and run, not the start of the acquisition. This allows capturing I2C and GPIO timestamps during configuration before the acquisition starts. |
+    | Source | The unique timestamp identifier that indicates the source serial channel for the LLP packet. |
+    | Data Type | The type of data contained in the LLP packet (i.e. Frame Start, Frame End, RAW types, YUV types, RGB types, etc.). |
+    | Virtual Channel | A number representing a virtual channel identifier. Virtual channel identifiers designate separate logical channels for data flows interleaved in the data path. |
+    | ECC | The Error Correction Code (ECC) detects bit errors in the header. |
+    | Word Count | The number of bytes in a long packet (i.e. payload size or bytes per line) and does not include the header or footer bytes. |
+    | Line Count | The Line Count value comes from the Word Count field in Line Start and Line End packets, which are optional. |
+    | Frame Count | The Frame Count value comes from the Word Count field in Frame Start and Frame End packets, which are mandatory, but there are no requirements on what the value is set to. |
+    | CRC | The Cyclic Redundancy Check (CRC) comes from the footer of every long packet and is used to determine the validity of the long packet payload data. |
 
 - **Bytes Acquired** - Displays the total number of bytes of LLP packet data acquired during the acquisition.
     > The **Bytes Acquired** indicator updates during the acquisition.
 - **Packets Logged** - Displays the total number of LLP packets logged during the acquisition.
     > The **Packets Logged** indicator updates after the acquisition completes.
+
 ### I2C Timestamps Tab
 > Note: To display I2C timestamp data, **Log I2C to Disk** must be enabled on the Resource tab and desired timestamp IDs must be added to the **timestamp filter** array on the I2C tab. The I2C timestamp data displayed is read from the User_Timestamps.tdms file and filtered to display only timestamp IDs included in the **timestamp filter** array.
 - **I2C Timestamps** - Displays I2C timestamp information for all I2C IDs in the **timestamp filter** array on the I2C tab. I2C timestamps begin logging immediately after the FPGA bitfile is downloaded and include timestamp data prior to the start of the LLP packet data acquisition, such as I2C traffic from the configuration script.
     > The **I2C Timestamps** display is updated after the acquisition completes.
+
 ### GPIO Timestamps Tab
 > Note: To display GPIO digital waveforms, **Log GPIO to Disk** must be enabled on the Resource tab and desired GPIO lines must be added to the **GPIO to Display** array on the GPIO tab. The GPIO timestamp data displayed is read from the GPIO_Timestamps.tdms file and filtered to display only GPIO lines included in the **GPIO to Display** array.
 - **GPIO Timestamps Waveform** - Displays a digital waveform for each GPIO line included in the **GPIO to Display** array on the GPIO tab. GPIO timestamps begin logging immediately after the FPGA bitfile is downloaded and include timestamp data prior to the start of the LLP packet data acquisition, such as toggles created from a reset.

--- a/docs/reference/gettingstartedexample/gse-acq-help.md
+++ b/docs/reference/gettingstartedexample/gse-acq-help.md
@@ -44,7 +44,7 @@ Refer to this document to understand the elements of the getting started example
     - **FPGA Display Parameters** - Parameters that determine what packet data the FPGA will send to the host for display.
             > Note: Display parameters only affect the image on the display channel, not any data logged to disk.
         - **virtual channel** - Number representing a Virtual Channel Identifier.
-            > Virtual channels identifiers designate separate logical channels for data flows interleaved in the data path.
+            > Virtual channel identifiers designate separate logical channels for data flows interleaved in the data path.
         - **payload data type** - Data type of the LLP packet payload for long packets.
             > Supported Options: YUV420 8-bit, YUV420 10-bit, Legacy YUV420 8-bit, YUV420 8-bit Chroma Shifted, YUV420 10-bit Chroma Shifted, YUV422 8-bit, YUV422 10-bit, RGB565, RGB666, RGB888, RAW 8, RAW 10, RAW 12, RAW 14, RAW 16.
         - **frame skip count** - Number of frames to skip between displayed frames.
@@ -124,6 +124,20 @@ Refer to this document to understand the elements of the getting started example
 > The getting started example displays packet data for the first two channels specified in the Channel Configurations array at the completion of the acquisition. If other packet data is desired, either re-order the active channels in the configuration array on the Serial Channel tab or use the TDMS File Viewer utility.
 - **Acquired Packets** - Displays the LLP packet information for the number of packets specified in the **Logged Packets to Display** control starting at the first logged packet.
     > Note: If displaying a large number of packets, the VI may appear unresponsive for a period of time after the acquisition completes while the packet data is processed.
+    
+   | Column | Description |
+   | ------ | ----------- |
+   | Index | The order packets were received. |
+   | Timestamp (s) | The time in seconds when the packet was received. Timestamps are relative to a time immediately after the FPGA bitfile is downloaded and run, not the start of the acquisition. This allows capturing I2C and GPIO timestamps during configuration before the acquisition starts. |
+   | Source | The unique timestamp identifier that indicates the source serial channel for the LLP packet. |
+   | Data Type | The type of data contained in the LLP packet (i.e. Frame Start, Frame End, RAW types, YUV types, RGB types, etc.). |
+   | Virtual Channel | A number representing a virtual channel identifier. Virtual channel identifiers designate separate logical channels for data flows interleaved in the data path. |
+   | ECC | The Error Correction Code (ECC) detects bit errors in the header. |
+   | Word Count | The number of bytes in a long packet (i.e. payload size or bytes per line) and does not include the header or footer bytes. |
+   | Line Count | The Line Count value comes from the Word Count field in Line Start and Line End packets, which are optional. |
+   | Frame Count | The Frame Count value comes from the Word Count field in Frame Start and Frame End packets, which are mandatory, but there are no requirements on what the value is set to. |
+   | CRC | The Cyclic Redundancy Check (CRC) comes from the footer of every long packet and is used to determine the validity of the long packet payload data. |
+
 - **Bytes Acquired** - Displays the total number of bytes of LLP packet data acquired during the acquisition.
     > The **Bytes Acquired** indicator updates during the acquisition.
 - **Packets Logged** - Displays the total number of LLP packets logged during the acquisition.

--- a/docs/reference/gettingstartedexample/gse-acq-help.md
+++ b/docs/reference/gettingstartedexample/gse-acq-help.md
@@ -10,13 +10,14 @@ Refer to this document to understand the elements of the getting started example
 ### Resource Tab
 - **RIO Device** - Resource name of the PXIe-148X device to be used.
 - **Bitfile Path** - Full path to an FPGA bitfile (.lvbitx) to be downloaded and run on the FPGA of the PXIe-148X. Depending on your PXIe-148X module, use the following bitfiles.
-    #### Table of PXIe-148X Acquisition Bitfiles
-    | **Interface Module**     | **Bitfile**                           |
-    |--------------------------|---------------------------------------|
-    | PXIe-1486 (8 In)         | PXIe_1486_8\_In.lvbitx                |
-    | PXIe-1486 (4 In 4 Out)   | PXIe_1486_4\_In_4\_Out_Acq_Tap.lvbitx |
-    | PXIe-1487 (8 In)         | PXIe_1487_8\_In.lvbitx                |
-    | PXIe-1487 (4 In 4 Out)   | PXIe_1487_4\_In_4\_Out_Acq_Tap.lvbitx |
+  #### Table of PXIe-148X Acquisition Bitfiles
+
+  | **Interface Module**     | **Bitfile**                           |
+  |--------------------------|---------------------------------------|
+  | PXIe-1486 (8 In)         | PXIe_1486_8\_In.lvbitx                |
+  | PXIe-1486 (4 In 4 Out)   | PXIe_1486_4\_In_4\_Out_Acq_Tap.lvbitx |
+  | PXIe-1487 (8 In)         | PXIe_1487_8\_In.lvbitx                |
+  | PXIe-1487 (4 In 4 Out)   | PXIe_1487_4\_In_4\_Out_Acq_Tap.lvbitx |
 
 - **TDMS File Directory** - Path to the directory used to store TDMS data files. 
     > If left blank the TDMS File Directory will be automatically populated with a path to a subfolder ("TDMS Files") within the getting started example root directory. TDMS data files include files for LLP packet acquisition, I2C timestamps, and GPIO timestamps.
@@ -31,15 +32,16 @@ Refer to this document to understand the elements of the getting started example
 ### Serial Channel Tab
 - **CSI-2 Data Source** - Selects the CSI-2 data source type. "Corrected" returns the received data after correcting for single-bit transmission errors. "Raw" returns the received data as is. 
 - **Configuration Script** - Full path to a script file used to configure the deserializer.
-    #### Table of PXIe-148X Acquisition Scripts
-    | **Interface Module**               | **Configuration Script**                                                   |
-    |------------------------------------|----------------------------------------------------------------------------|
-    | PXIe-1486 (8 In)                   | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
-    | PXIe-1486 (4 In 4 Out)             | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
-    | PXIe-1487 (8 In) Even Channels     | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_A.cpp         |
-    | PXIe-1487 (8 In) Odd Channels      | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_B.cpp         |
-    | PXIe-1487 (8 In) Adjacent Channels | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID01_RevSplit.cpp |
-    | PXIe-1487 (4 In 4 Out)             | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_B.cpp         |
+  #### Table of PXIe-148X Acquisition Scripts
+
+  | **Interface Module**               | **Configuration Script**                                                   |
+  |------------------------------------|----------------------------------------------------------------------------|
+  | PXIe-1486 (8 In)                   | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
+  | PXIe-1486 (4 In 4 Out)             | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
+  | PXIe-1487 (8 In) Even Channels     | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_A.cpp         |
+  | PXIe-1487 (8 In) Odd Channels      | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_B.cpp         |
+  | PXIe-1487 (8 In) Adjacent Channels | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID01_RevSplit.cpp |
+  | PXIe-1487 (4 In 4 Out)             | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_B.cpp         |
 
 - **Channel Configurations** - Array of active serial channels and display parameters for each channel.
     - **Serial Channel** - String representing the active serial channel in the format "SI" for Serial Input or "SO" for Serial Output followed by the channel number (i.e. "SI0")
@@ -131,19 +133,20 @@ Refer to this document to understand the elements of the getting started example
 > The getting started example displays packet data for the first two channels specified in the Channel Configurations array at the completion of the acquisition. If other packet data is desired, either re-order the active channels in the configuration array on the Serial Channel tab or use the TDMS File Viewer utility.
 - **Acquired Packets** - Displays the LLP packet information for the number of packets specified in the **Logged Packets to Display** control starting at the first logged packet.
     > Note: If displaying a large number of packets, the VI may appear unresponsive for a period of time after the acquisition completes while the packet data is processed.
-    #### Table of Descriptions for Acquired Packets Columns
-    | Column | Description |
-    | ------ | ----------- |
-    | Index | The order packets were received. |
-    | Timestamp (s) | The time in seconds when the packet was received. Timestamps are relative to a time immediately after the FPGA bitfile is downloaded and run, not the start of the acquisition. This allows capturing I2C and GPIO timestamps during configuration before the acquisition starts. |
-    | Source | The unique timestamp identifier that indicates the source serial channel for the LLP packet. |
-    | Data Type | The type of data contained in the LLP packet (i.e. Frame Start, Frame End, RAW types, YUV types, RGB types, etc.). |
-    | Virtual Channel | A number representing a virtual channel identifier. Virtual channel identifiers designate separate logical channels for data flows interleaved in the data path. |
-    | ECC | The Error Correction Code (ECC) detects bit errors in the header. |
-    | Word Count | The number of bytes in a long packet (i.e. payload size or bytes per line) and does not include the header or footer bytes. |
-    | Line Count | The Line Count value comes from the Word Count field in Line Start and Line End packets, which are optional. |
-    | Frame Count | The Frame Count value comes from the Word Count field in Frame Start and Frame End packets, which are mandatory, but there are no requirements on what the value is set to. |
-    | CRC | The Cyclic Redundancy Check (CRC) comes from the footer of every long packet and is used to determine the validity of the long packet payload data. |
+  #### Table of Descriptions for Acquired Packets Columns
+
+  | Column | Description |
+  | ------ | ----------- |
+  | Index | The order packets were received. |
+  | Timestamp (s) | The time in seconds when the packet was received. Timestamps are relative to a time immediately after the FPGA bitfile is downloaded and run, not the start of the acquisition. This allows capturing I2C and GPIO timestamps during configuration before the acquisition starts. |
+  | Source | The unique timestamp identifier that indicates the source serial channel for the LLP packet. |
+  | Data Type | The type of data contained in the LLP packet (i.e. Frame Start, Frame End, RAW types, YUV types, RGB types, etc.). |
+  | Virtual Channel | A number representing a virtual channel identifier. Virtual channel identifiers designate separate logical channels for data flows interleaved in the data path. |
+  | ECC | The Error Correction Code (ECC) detects bit errors in the header. |
+  | Word Count | The number of bytes in a long packet (i.e. payload size or bytes per line) and does not include the header or footer bytes. |
+  | Line Count | The Line Count value comes from the Word Count field in Line Start and Line End packets, which are optional. |
+  | Frame Count | The Frame Count value comes from the Word Count field in Frame Start and Frame End packets, which are mandatory, but there are no requirements on what the value is set to. |
+  | CRC | The Cyclic Redundancy Check (CRC) comes from the footer of every long packet and is used to determine the validity of the long packet payload data. |
 
 - **Bytes Acquired** - Displays the total number of bytes of LLP packet data acquired during the acquisition.
     > The **Bytes Acquired** indicator updates during the acquisition.

--- a/docs/reference/gettingstartedexample/gse-acq-help.md
+++ b/docs/reference/gettingstartedexample/gse-acq-help.md
@@ -11,7 +11,6 @@ Refer to this document to understand the elements of the getting started example
 - **RIO Device** - Resource name of the PXIe-148X device to be used.
 - **Bitfile Path** - Full path to an FPGA bitfile (.lvbitx) to be downloaded and run on the FPGA of the PXIe-148X. Depending on your PXIe-148X module, use the following bitfiles.
   #### Table of PXIe-148X Acquisition Bitfiles
-
   | **Interface Module**     | **Bitfile**                           |
   |--------------------------|---------------------------------------|
   | PXIe-1486 (8 In)         | PXIe_1486_8\_In.lvbitx                |
@@ -33,7 +32,6 @@ Refer to this document to understand the elements of the getting started example
 - **CSI-2 Data Source** - Selects the CSI-2 data source type. "Corrected" returns the received data after correcting for single-bit transmission errors. "Raw" returns the received data as is. 
 - **Configuration Script** - Full path to a script file used to configure the deserializer.
   #### Table of PXIe-148X Acquisition Scripts
-
   | **Interface Module**               | **Configuration Script**                                                   |
   |------------------------------------|----------------------------------------------------------------------------|
   | PXIe-1486 (8 In)                   | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
@@ -106,6 +104,7 @@ Refer to this document to understand the elements of the getting started example
 ### I2C Tab
 - **timestamp filter** - Specifies I2C timestamp IDs to display after the acquisition completes.  I2C timestamps with IDs not matching an ID included in the timestamp filter array are logged, but not displayed.
     > User24 represents the I2C traffic on serial channel 0 (SI0), User25 represents the I2C traffic on serial channel 1 (SI1), and so on.
+
 ### GPIO Tab
 - **GPIO to Display** - Specifies GPIO timestamp identifiers to display on the _GPIO Timestamps Waveform_ after the acquisition completes.  Timestamps for GPIO lines not included in the _GPIO to Display_ array are logged, but not displayed.
 - **GPIO Bank Select** - Specifies the GPIO bank used for the **GPIO Bank Read** and **GPIO Bank Write** controls during the acquisition.
@@ -134,7 +133,6 @@ Refer to this document to understand the elements of the getting started example
 - **Acquired Packets** - Displays the LLP packet information for the number of packets specified in the **Logged Packets to Display** control starting at the first logged packet.
     > Note: If displaying a large number of packets, the VI may appear unresponsive for a period of time after the acquisition completes while the packet data is processed.
   #### Table of Descriptions for Acquired Packets Columns
-
   | Column | Description |
   | ------ | ----------- |
   | Index | The order packets were received. |

--- a/docs/reference/gettingstartedexample/gse-acq-help.md
+++ b/docs/reference/gettingstartedexample/gse-acq-help.md
@@ -10,14 +10,14 @@ Refer to this document to understand the elements of the getting started example
 ### Resource Tab
 - **RIO Device** - Resource name of the PXIe-148X device to be used.
 - **Bitfile Path** - Full path to an FPGA bitfile (.lvbitx) to be downloaded and run on the FPGA of the PXIe-148X. Depending on your PXIe-148X module, use the following bitfiles.
-#### Table of PXIe-148X Acquisition Bitfiles
-    
-  | **Interface Module**     | **Bitfile**                           |
-  |--------------------------|---------------------------------------|
-  | PXIe-1486 (8 In)         | PXIe_1486_8\_In.lvbitx                |
-  | PXIe-1486 (4 In 4 Out)   | PXIe_1486_4\_In_4\_Out_Acq_Tap.lvbitx |
-  | PXIe-1487 (8 In)         | PXIe_1487_8\_In.lvbitx                |
-  | PXIe-1487 (4 In 4 Out)   | PXIe_1487_4\_In_4\_Out_Acq_Tap.lvbitx |
+    #### Table of PXIe-148X Acquisition Bitfiles
+    | **Interface Module**     | **Bitfile**                           |
+    |--------------------------|---------------------------------------|
+    | PXIe-1486 (8 In)         | PXIe_1486_8\_In.lvbitx                |
+    | PXIe-1486 (4 In 4 Out)   | PXIe_1486_4\_In_4\_Out_Acq_Tap.lvbitx |
+    | PXIe-1487 (8 In)         | PXIe_1487_8\_In.lvbitx                |
+    | PXIe-1487 (4 In 4 Out)   | PXIe_1487_4\_In_4\_Out_Acq_Tap.lvbitx |
+
 - **TDMS File Directory** - Path to the directory used to store TDMS data files. 
     > If left blank the TDMS File Directory will be automatically populated with a path to a subfolder ("TDMS Files") within the getting started example root directory. TDMS data files include files for LLP packet acquisition, I2C timestamps, and GPIO timestamps.
 - **Display Acquired Images** - Enable to display acquired images.
@@ -31,9 +31,7 @@ Refer to this document to understand the elements of the getting started example
 ### Serial Channel Tab
 - **CSI-2 Data Source** - Selects the CSI-2 data source type. "Corrected" returns the received data after correcting for single-bit transmission errors. "Raw" returns the received data as is. 
 - **Configuration Script** - Full path to a script file used to configure the deserializer.
-
     #### Table of PXIe-148X Acquisition Scripts
-    
     | **Interface Module**               | **Configuration Script**                                                   |
     |------------------------------------|----------------------------------------------------------------------------|
     | PXIe-1486 (8 In)                   | Host\\Scripts\\DS90UB954\\Acq\\LI\\IMX490_2880x1280_RAW12.py               |
@@ -42,6 +40,7 @@ Refer to this document to understand the elements of the getting started example
     | PXIe-1487 (8 In) Odd Channels      | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_B.cpp         |
     | PXIe-1487 (8 In) Adjacent Channels | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID01_RevSplit.cpp |
     | PXIe-1487 (4 In 4 Out)             | Host\\Scripts\\MAX9296A\\Acq\\LI\\IMX490_2880x1280_RAW12_ID1_B.cpp         |
+
 - **Channel Configurations** - Array of active serial channels and display parameters for each channel.
     - **Serial Channel** - String representing the active serial channel in the format "SI" for Serial Input or "SO" for Serial Output followed by the channel number (i.e. "SI0")
     - **FPGA Display Parameters** - Parameters that determine what packet data the FPGA will send to the host for display.
@@ -132,9 +131,7 @@ Refer to this document to understand the elements of the getting started example
 > The getting started example displays packet data for the first two channels specified in the Channel Configurations array at the completion of the acquisition. If other packet data is desired, either re-order the active channels in the configuration array on the Serial Channel tab or use the TDMS File Viewer utility.
 - **Acquired Packets** - Displays the LLP packet information for the number of packets specified in the **Logged Packets to Display** control starting at the first logged packet.
     > Note: If displaying a large number of packets, the VI may appear unresponsive for a period of time after the acquisition completes while the packet data is processed.
-  
     #### Table of Descriptions for Acquired Packets Columns
-
     | Column | Description |
     | ------ | ----------- |
     | Index | The order packets were received. |

--- a/docs/reference/gettingstartedexample/gse-acq-help.md
+++ b/docs/reference/gettingstartedexample/gse-acq-help.md
@@ -143,12 +143,12 @@ Refer to this document to understand the elements of the getting started example
   | Index | The order packets were received. |
   | Timestamp (s) | The time in seconds when the packet was received. Timestamps are relative to a time immediately after the FPGA bitfile is downloaded and run, not the start of the acquisition. This allows capturing I2C and GPIO timestamps during configuration before the acquisition starts. |
   | Source | The unique timestamp identifier that indicates the source serial channel for the LLP packet. |
-  | Data Type | The type of data contained in the LLP packet (i.e. Frame Start, Frame End, RAW types, YUV types, RGB types, etc.). |
+  | Data Type | The type of data contained in the LLP packet (e.g. Frame Start, Frame End, RAW types, YUV types, RGB types, etc.). |
   | Virtual Channel | A number representing a virtual channel identifier. Virtual channel identifiers designate separate logical channels for data flows interleaved in the data path. |
   | ECC | The Error Correction Code (ECC) detects bit errors in the header. |
   | Word Count | The number of bytes in a long packet (i.e. payload size or bytes per line) and does not include the header or footer bytes. |
-  | Line Count | The Line Count value comes from the Word Count field in Line Start and Line End packets, which are optional. |
-  | Frame Count | The Frame Count value comes from the Word Count field in Frame Start and Frame End packets, which are mandatory, but there are no requirements on what the value is set to. |
+  | Line Count | The Line Count value comes from the Word Count field in Line Start and Line End packets. |
+  | Frame Count | The Frame Count value comes from the Word Count field in Frame Start and Frame End packets, but there are no requirements on what the value is set to. |
   | CRC | The Cyclic Redundancy Check (CRC) comes from the footer of every long packet and is used to determine the validity of the long packet payload data. |
 
 - **Bytes Acquired** - Displays the total number of bytes of LLP packet data acquired during the acquisition.

--- a/docs/tutorials/gettingstartedexample/gse-acq-basic.md
+++ b/docs/tutorials/gettingstartedexample/gse-acq-basic.md
@@ -135,6 +135,7 @@ A supported interface module and camera on a PXI system running Windows.
     > Packet Data is displayed in the **First Serial Channel Packets** tab.
     - The **Bytes Acquired (1st Channel)** indicator updates as the acquisition is occurring.
     - The **Packets Logged (1st Channel)** indicator updates after acquisition completes.
+    > See [PXIe-148X Acquisition GSE Help](../../reference/gettingstartedexample/gse-acq-help.md#table-of-descriptions-for-acquired-packets-columns) for **Acquired Packets (1st Channel)** column details.
 
     ![First Serial Channel Packets Tab](../../images/PXIe-148X-Acq-FirstSerialChannelPackets-FiniteAcq.png)
 

--- a/docs/tutorials/gettingstartedexample/gse-acq-basic.md
+++ b/docs/tutorials/gettingstartedexample/gse-acq-basic.md
@@ -2,7 +2,7 @@
 
 This tutorial will teach you the steps needed to configure an acquisition using a PXIe-148X module with a Leopard Imaging IMX490 camera and familiarize you with the basic functionality provided by the Acquisition Getting Started Example.
 
-**Note:** This document references the example included with the NI-FlexRIO 22Q3 driver. Examples included in newer releases of the driver should be appliable.
+> Note: This document references the example included with the NI-FlexRIO 22Q3 driver. Examples included in newer releases of the driver should be applicable.
 
 ## Prerequisites
 
@@ -46,7 +46,7 @@ A supported interface module and camera on a PXI system running Windows.
 
 ## Performing a Simple Continuous Acquisition
 
-> **Note:** For the purposes of this tutorial, all input control values not specified should be left as the default value.
+> Note: For the purposes of this tutorial, all input control values not specified should be left as the default value.
 
 1.  Select the **Resource** tab and make the following modifications.
     - Select the **RIO Device** from the dropdown menu that corresponds to your interface module.
@@ -96,6 +96,7 @@ A supported interface module and camera on a PXI system running Windows.
 
 8. Rerun the VI to see the impact of the display parameter changes on the image displayed.
     > Note: Changes made to the display parameters while the VI is running will not take effect until the next time the VI is run.
+
 ## Performing a Finite Acquisition with Data Logging
 
 > Note: The Finite Acquisition with Data Logging tutorial assumes that all input parameters are still configured as specified in the Simple Continuous Acquisition tutorial.

--- a/docs/tutorials/gettingstartedexample/gse-acq-common.md
+++ b/docs/tutorials/gettingstartedexample/gse-acq-common.md
@@ -60,7 +60,7 @@ This tutorial shows you how to acquire packets from a camera on a serial channel
 
         > Note: Specifying a large number of packets to display may cause the VI to appear unresponsive for a period of time after the acquisition completes while the packet data is processed. A negative **Logged Packets to Display** value displays all logged packets.
         
-        > Note: Timestamps are relative to a time immediately after the FPGA bitfile is downloaded and run, not the start of the acquisition. This allows capturing I2C and GPIO timestamps during configuration before the acquisition starts.
+        > See [PXIe-148X Acquisition GSE Help](../../reference/gettingstartedexample/gse-acq-help.md#table-of-descriptions-for-acquired-packets-columns) for **Acquired Packets (1st Channel)** column details.
 
     - The **Bytes Acquired (1st Channel)** indicator updates during the acquisition.
     - The **Packets Logged (1st Channel)** indicator updates after the acquisition completes.

--- a/docs/tutorials/gettingstartedexample/gse-acq-common.md
+++ b/docs/tutorials/gettingstartedexample/gse-acq-common.md
@@ -2,13 +2,13 @@
 
 This document covers a range of common scenarios using the PXIe-148X Acquisition Getting Started Example (GSE) to help you understand LLP acquisition, I2C and GPIO timestamping, and common configuration options.
 
-**Note:** This document references the example included with the NI-FlexRIO 22Q3 driver. Examples included in newer releases of the driver should be appliable.
+> Note: This document references the example included with the NI-FlexRIO 22Q3 driver. Examples included in newer releases of the driver should be appliable.
 
 ## Prerequisites
 
 This tutorial is written for users who understand how to perform a basic acquisition with a PXIe-148X GMSL or FPD-Link interface module. It is recommended to complete the [PXIe-148X Getting Started Example - Basic Acquisition Tutorial](gse-acq-basic.md) before attempting this tutorial.
 
-**Note:** The tutorials in this document assume the use of a Leopard Imaging IMX490 camera connected to SI0 of your interface module (see PXIe-148X Getting Started Example - Basic Acquisition Tutorial for specific setup if needed).
+> Note: The tutorials in this document assume the use of a Leopard Imaging IMX490 camera connected to SI0 of your interface module (see PXIe-148X Getting Started Example - Basic Acquisition Tutorial for specific setup if needed).
 
 ## Acquiring and Filtering LLP Packets
 
@@ -163,6 +163,7 @@ This section demonstrates useful techniques for reducing the system bandwidth ne
 
     - Select the **First Display Channel** tab and observe the change to the horizontal resolution for the image.
     - Select the **First Serial Channel Packets** tab and observe the **Word Count** (bytes) for each RAW 12 packet type is unchanged.
+
 #### Reducing Vertical Resolution
 
 1. Run the VI.
@@ -264,12 +265,11 @@ This tutorial shows you how to configure the **RAW Display Parameters** to chang
 
    - Select the **First Display Channel** tab and observe the image displayed looks correct. The **RAW Display Parameters** now match the RAW 12 packet data from the Leopard Imaging IMX490 camera.
 
-
 ## Setting Serial Channel Configurations
 
 This tutorial shows you how to configure the **Serial Channel** tab to acquire multiple images from multiple camera sensors.
 
-> **Note:** This tutorial requires the use of two Leopard Imaging IMX490 cameras connected to SI0 and SI1 of your interface module.
+> Note: This tutorial requires the use of two Leopard Imaging IMX490 cameras connected to SI0 and SI1 of your interface module.
 
 1. Set the following controls on the Acquisition Example GSE VI and leave all other values at their defaults.
     > Note: VI controls and indicators can be reset to default values by clicking on the **Edit** menu and selecting the **Reinitialize Values to Default** option.


### PR DESCRIPTION
- Add descriptions for the columns in the Acquired Packets table to the acquisition help document.
- Add links to the new table from each of the acquisition tutorial documents. 
- General formatting fixes to the Acquisition help and tutorials documents.
