### PR TITLE
Improvements to File Viewer and FPGA Display Parameters tutorial sect…

### DIFF
--- a/docs/tutorials/gettingstartedexample/gse-acq-basic.md
+++ b/docs/tutorials/gettingstartedexample/gse-acq-basic.md
@@ -176,7 +176,10 @@ TDMS files containing acquired data from the camera were saved to the \"TDMS Fil
 
     > Note: The **Update TDMS File Packet Offset Data** control is enabled by default. Enabling this option results in re-saving a TDMS file with additional packet indexing information the first time the TDMS file is loaded. This indexing information can reduce the future load time of the file, particularly when reading only a subset of the packet data.
 
-4. (Optional) Update the **Packet Display Start Index** and **Packets to Display** controls to review a specific packet range of interest from the TDMS file and rerun the VI.
+4. (Optional) Update the **Packet Display Start Index** and **Packets to Display** controls to review a specific packet range of interest from the TDMS file and rerun the VI. 
+    > Using an LI-IMX490-GMSL2 camera with a vertical resolution of 1280, each frame contains a Frame Start packet followed by 1280 RAW 12 packets and a Frame End packet. To display 10 frames of data starting at the second frame, set **Packet Display Start Index** to <font face = "courier new">1282</font> and **Packets to Display** to <font face = "courier new">12820</font>.
+
+    > Note: Setting **Packets to Display** to <font face = "courier new">-1</font> displays packets from **Packet Display Start Index** to the end of the file.
 
 ## Related Documents
 - [PXIe-148X Getting Started Example - Common Acquisition Tutorials](./gse-acq-common.md)

--- a/docs/tutorials/gettingstartedexample/gse-acq-common.md
+++ b/docs/tutorials/gettingstartedexample/gse-acq-common.md
@@ -137,9 +137,25 @@ This tutorial shows you how to configure the **FPGA Display Parameters** to chan
 
 2. Run the VI.
 
-3. Select the **First Display Channel** tab. Images from the camera are displayed on this tab. 
+3. Select the **First Display Channel** tab and verify that images from the camera are displayed on this tab. 
 
     - Note the two FPS indicators. The **Source Rate (fps)** indicator displays the frame rate in frames per second at which the image data is being received. The **Update Rate (fps)** indicator displays the rate in frames per second at which the image display indicator is being updated.
+
+4. Select the **Serial Channel** tab and make the following modifications.
+    - Set the **virtual channel** to <font face = "courier new">1</font>.
+
+5. Run the VI and verify that no images are displayed on the **First Display Channel** tab since the **virtual channel** value does not match the value in the packets received from the camera. 
+
+6. Select the **Serial Channel** tab and make the following modifications.
+    - Set the **virtual channel** to <font face = "courier new">0</font>.
+    - Set the **payload data type** to **RAW 10**.
+
+7. Run the VI and verify that no images are displayed on the **First Display Channel** tab since the **payload data type** value does not match the value in the packets received from the camera.
+
+8. Select the **Serial Channel** tab and make the following modifications.
+    - Set the **payload data type** to **RAW 12**.
+
+9. Run the VI and verify that images are once again displayed on the **First Display Channel** tab since the **virtual channel** and **payload data type** values now match the values in the packets received from the camera.
 
 ### Reducing System Bandwidth Usage
 This section demonstrates useful techniques for reducing the system bandwidth needed to transfer data from the FPGA to the host.


### PR DESCRIPTION
Improve TDMS File View section of the Basic Acquisition Tutorial document to explain Packet Display Start Index and Packets to Display controls.
Improve FPGA Display Parameters section of the Common Acquisition Tutorial document to add steps to modify the **virtual channel** and **payload data type** controls and verify the resulting impact on the displayed images.
