### PR TITLE
Add 148x module variant table

### DIFF
--- a/docs/reference/hardware/automotive-camera-module-variants.md
+++ b/docs/reference/hardware/automotive-camera-module-variants.md
@@ -16,15 +16,15 @@ This document includes reference information on various properties of PXIe-148x 
 | Heading | Definition |
 |-|-|
 | Model Number             | Generic model name associated with a family of products. Often used in shipping example code and help documentation. |
-| Channels                 | Number and type of serial channels |
-| Protocol                 | Supported CSI-2 protocol and generation |
-| Serializer               | Specific serializer of the module, if applicable |
-| Deserializer             | Specific deserializer of the module, if applicable |
-| Slot Count               | The number of physical slots required in a PXIe chassis for a given module |
-| Front Panel Overlay      | Name printed on the front panel of the physical module |
-| NI MAX Name              | The name of a module shown in NI Max |
-| LabVIEW FPGA Target Name | The name of an FPGA Target for a module shown in a LabVIEW Project |
-| FlexRIO First Supported  | The first NI-FlexRIO driver version to support a given module |
+| Channels                 | Number and type of serial channels. |
+| Protocol                 | Supported CSI-2 protocol and generation. |
+| Serializer               | Specific serializer of the module, if applicable. |
+| Deserializer             | Specific deserializer of the module, if applicable. |
+| Slot Count               | The number of physical slots required in a PXIe chassis for a given module. |
+| Front Panel Overlay      | Name printed on the front panel of the physical module. |
+| NI MAX Name              | The name of a module shown in NI Max. |
+| LabVIEW FPGA Target Name | The name of an FPGA Target for a module shown in a LabVIEW Project. |
+| FlexRIO First Supported  | The first NI-FlexRIO driver version to support a given module. |
 | Product ID               | FlexRIO driver product ID. Occasionally referenced in example code or help text. |
 | Variant ID               | FlexRIO driver variant ID used to distinguish similar modules. Occasionally referenced in example code or help text. |
 

--- a/docs/reference/hardware/automotive-camera-module-variants.md
+++ b/docs/reference/hardware/automotive-camera-module-variants.md
@@ -1,0 +1,81 @@
+# PXIe-148X Automotive Camera Module Details
+{: .no_toc }
+
+This document includes reference information on various properties of PXIe-148x automotive camera modules and links to related specifications.
+
+### Table of contents
+{: .no_toc }
+
+1. TOC
+{:toc}
+
+---
+
+## Table Heading Definitions
+
+| Heading | Definition |
+|-|-|
+| Model Number             | Generic model name associated with a family of products. Often used in shipping example code and help documentation. |
+| Channels                 | Number and type of serial channels |
+| Protocol                 | Supported CSI-2 protocol and generation |
+| Serializer               | Specific serializer of the module, if applicable |
+| Deserializer             | Specific deserializer of the module, if applicable |
+| Slot Count               | The number of physical slots required in a PXIe chassis for a given module |
+| Front Panel Overlay      | Name printed on the front panel of the physical module |
+| NI MAX Name              | The name of a module shown in NI Max |
+| LabVIEW FPGA Target Name | The name of an FPGA Target for a module shown in a LabVIEW Project |
+| FlexRIO First Supported  | The first NI-FlexRIO driver version to support a given module |
+| Product ID               | FlexRIO driver product ID. Occasionally referenced in example code or help text. |
+| Variant ID               | FlexRIO driver variant ID used to distinguish similar modules. Occasionally referenced in example code or help text. |
+
+---
+
+## PXIe-1486 FlexRIO FPD-Link III Modules
+
+### Hardware Details
+
+| Model Number           | Channels     | Protocol     | Serializer | Deserializer | Slot Count | Front Panel Overlay                    |
+|------------------------|--------------|--------------|------------|--------------|------------|----------------------------------------|
+| PXIe-1486 Deserializer | 8 input      | FPD-Link III | N/A        | DS90UB954    | 2          | FlexRIO FPD-LINK™ III 954 Deserializer |
+| PXIe-1486 Serializer   | 8 output     | FPD-Link III | DS90UB953  | N/A          | 2          | FlexRIO FPD-LINK™ III 953 Serializer   |
+| PXIe-1486 SerDes       | 4 in / 4 out | FPD-Link III | DS90UB953  | DS90UB954    | 2          | FlexRIO FPD-LINK™ III 953/954 SerDes   |
+
+### Software Details
+
+| Model Number           | NI MAX Name                                        | LabVIEW FPGA Target Name          | FlexRIO First Supported | Product ID | Variant ID |
+|------------------------|----------------------------------------------------|-----------------------------------|-------------------------|------------|------------|
+| PXIe-1486 Deserializer | NI PXIe-1486 (8 In - 954 Deserializer - KU11P)     | NI PXIe-1486 (8 In - KU11P)       | [20.6](#compat-note)    | 0x7A82     | 0x01       |
+| PXIe-1486 Serializer   | NI PXIe-1486 (8 Out - 953 Serializer - KU11P)      | NI PXIe-1486 (8 Out - KU11P)      | [20.7](#compat-note)    | 0x7A83     | 0x02       |
+| PXIe-1486 SerDes       | NI PXIe-1486 (4 In 4 Out - 953/954 SerDes - KU11P) | NI PXIe-1486 (4 In 4 Out - KU11P) | [20.6](#compat-note)    | 0x7A84     | 0x03       |
+
+---
+
+## PXIe-1487 FlexRIO GMSL2 Modules
+
+### Hardware Details
+
+| Model Number           | Channels     | Protocol | Serializer | Deserializer | Slot Count | Front Panel Overlay              |
+|------------------------|--------------|----------|------------|--------------|------------|----------------------------------|
+| PXIe-1487 Deserializer | 8 input      | GMSL1/2  | N/A        | MAX9296A     | 2          | FlexRIO GMSL2 9296A Deserializer |
+| PXIe-1487 Serializer   | 8 output     | GMSL1/2  | MAX9295A   | N/A          | 2          | FlexRIO GMSL2 9295A Serializer   |
+| PXIe-1487 SerDes       | 4 in / 4 out | GMSL1/2  | MAX9295A   | MAX9296A     | 2          | FlexRIO GMSL2 9295A/9296A SerDes |
+
+### Software Details
+
+| Model Number           | NI MAX Name                                            | LabVIEW FPGA Target Name          | FlexRIO First Supported | Product ID | Variant ID |
+|------------------------|--------------------------------------------------------|-----------------------------------|-------------------------|------------|------------|
+| PXIe-1487 Deserializer | NI PXIe-1487 (8 In - 9296A Deserializer - KU11P)       | NI PXIe-1487 (8 In - KU11P)       | [20.6](#compat-note)    | 0x7A85     | 0x01       |
+| PXIe-1487 Serializer   | NI PXIe-1487 (8 Out - 9295A Serializer - KU11P)        | NI PXIe-1487 (8 Out - KU11P)      | [20.7](#compat-note)    | 0x7A86     | 0x02       |
+| PXIe-1487 SerDes       | NI PXIe-1487 (4 In/4 Out - 9295A/9296A SerDes - KU11P) | NI PXIe-1487 (4 In 4 Out - KU11P) | [20.6](#compat-note)    | 0x7A87     | 0x03       |
+
+<a id="compat-note"></a>
+> (\*) Full details on hardware and OS compatibility can be found [here on ni.com](https://www.ni.com/en-us/support/documentation/compatibility/21/ni-hardware-and-operating-system-compatibility.html)
+
+---
+
+## Related Documents
+
+- [PXIe-1486 Getting Started Guide](https://www.ni.com/docs/en-US/bundle/pxie-1486-getting-started/page/intro.html)
+- [PXIe-1486 Specifications](https://www.ni.com/docs/en-US/bundle/pxie-1486-specs/page/specs.html)
+- [PXIe-1487 Getting Started Guide](https://www.ni.com/docs/en-US/bundle/pxie-1487-getting-started/page/intro.html)
+- [PXIe-1487 Specifications](https://www.ni.com/docs/en-US/bundle/pxie-1487-specs/page/specs.html)    


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add a table of commonly useful details describing the different PXIe-148x module variants.

Published version can be viewed here:
https://hernstrom.github.io/automotive-camera-module-reference/reference/hardware/automotive-camera-module-variants.html