### PR TITLE
First pass adding 1488 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ automotive-camera-module-reference is a repository for documentation and
 support collateral for NI's automotive camera modules:
 - PXIe-1486
 - PXIe-1487
+- PXIe-1488

--- a/docs/reference/gettingstartedexample/gse-acq-help.md
+++ b/docs/reference/gettingstartedexample/gse-acq-help.md
@@ -27,6 +27,8 @@ Refer to this document to understand the elements of the getting started example
   | PXIe-1486 (4 In 4 Out)   | PXIe_1486_4\_In_4\_Out_Acq_Tap.lvbitx |
   | PXIe-1487 (8 In)         | PXIe_1487_8\_In.lvbitx                |
   | PXIe-1487 (4 In 4 Out)   | PXIe_1487_4\_In_4\_Out_Acq_Tap.lvbitx |
+  | PXIe-1488 (8 In)         | PXIe_1488_8\_In.lvbitx                |
+  | PXIe-1488 (4 In 4 Out)   | PXIe_1488_4\_In_4\_Out_Acq_Tap.lvbitx |
 
 - **TDMS File Directory** - Path to the directory used to store TDMS data files. 
     > If left blank the TDMS File Directory will be automatically populated with a path to a subfolder ("TDMS Files") within the getting started example root directory. TDMS data files include files for LLP packet acquisition, I2C timestamps, and GPIO timestamps.

--- a/docs/reference/gettingstartedexample/gse-gen-help.md
+++ b/docs/reference/gettingstartedexample/gse-gen-help.md
@@ -27,6 +27,8 @@ Refer to this document to understand the elements of the getting started example
   | PXIe-1486 (4 In 4 Out) | <font face = "courier new">PXIe_1486_4\_In_4\_Out_Gen.lvbitx</font>     |
   | PXIe-1487 (8 Out)      | <font face = "courier new">PXIe_1487_8\_Out.lvbitx</font>               |
   | PXIe-1487 (4 In 4 Out) | <font face = "courier new">PXIe_1487_4\_In_4\_Out_Gen.lvbitx</font>     |
+  | PXIe-1488 (8 Out)      | <font face = "courier new">PXIe_1488_8\_Out.lvbitx</font>               |
+  | PXIe-1488 (4 In 4 Out) | <font face = "courier new">PXIe_1488_4\_In_4\_Out_Gen.lvbitx</font>     |
 
 - **TDMS File Directory** - Path to the directory used to load TDMS data files. 
     > If left blank, the TDMS File Directory is automatically populated with a path to a <font face="courier new">TDMS Files</font> subfolder within the getting started example root directory. TDMS data files include files for LLP packet data, I2C timestamps, and GPIO timestamps.

--- a/docs/reference/gettingstartedexample/gse-tap-help.md
+++ b/docs/reference/gettingstartedexample/gse-tap-help.md
@@ -236,5 +236,5 @@ Refer to this document to understand the elements of the getting started example
 ## Related Documents
 - [PXIe-148X Getting Started Example - Basic Tap Tutorial](../../tutorials/gettingstartedexample/gse-tap-basic.md)
 - [PXIe-148X Getting Started Example - Common Tap Tutorials](../../tutorials/gettingstartedexample/gse-tap-common.md)
-- [PXIe-148X Getting Started Example - acq Help](./gse-acq-help.md)
+- [PXIe-148X Getting Started Example - Acquisition Help](./gse-acq-help.md)
 - [PXIe-148X Getting Started Example - Tap Help](./gse-tap-help.md)

--- a/docs/reference/hardware/automotive-camera-module-variants.md
+++ b/docs/reference/hardware/automotive-camera-module-variants.md
@@ -89,6 +89,26 @@ This document contains reference information on various properties of PXIe-148X 
 | PXIe-1487 Serializer   | NI PXIe-1487 (8 Out - 96717F Serializer - KU11P)         | NI PXIe-1487 (8 Out - KU11P)      | [2023 Q1](#compat-note)    | 0x7A86     | 1487_8O     |
 | PXIe-1487 SerDes       | NI PXIe-1487 (4 In/4 Out - 96717F/96716A SerDes - KU11P) | NI PXIe-1487 (4 In 4 Out - KU11P) | [2023 Q1](#compat-note)    | 0x7A87     | 1487_4I_4O  |
 
+---
+
+## PXIe-1488 FlexRIO FPD-Link IV Modules
+
+### Hardware Details
+
+| Model Number           | Channels     | Protocol    | Serializer | Deserializer | Slot Count | Front Panel Overlay                     |
+|------------------------|--------------|-------------|------------|--------------|------------|-----------------------------------------|
+| PXIe-1488 Deserializer | 8 input      | FPD-Link IV | N/A        | DS90UB902    | 2          | FlexRIO FPD-LINK™ III 9702 Deserializer |
+| PXIe-1488 Serializer   | 8 output     | FPD-Link IV | DS90UB971  | N/A          | 2          | FlexRIO FPD-LINK™ III 971 Serializer    |
+| PXIe-1488 SerDes       | 4 in / 4 out | FPD-Link IV | DS90UB971  | DS90UB9702   | 2          | FlexRIO FPD-LINK™ III 971/9702 SerDes   |
+
+### Software Details
+
+| Model Number           | NI MAX Name                                         | LabVIEW FPGA Target Name          | FlexRIO First Supported    | Product ID | Model Alias |
+|------------------------|-----------------------------------------------------|-----------------------------------|----------------------------|------------|-------------|
+| PXIe-1488 Deserializer | NI PXIe-1488 (8 In - 9702 Deserializer - KU11P)     | NI PXIe-1488 (8 In - KU11P)       | [2023 Q2](#compat-note)    | 0x7AE4     | 1488_8I     |
+| PXIe-1488 Serializer   | NI PXIe-1488 (8 Out - 971 Serializer - KU11P)       | NI PXIe-1488 (8 Out - KU11P)      | [2023 Q2](#compat-note)    | 0x7AE5     | 1488_8O     |
+| PXIe-1488 SerDes       | NI PXIe-1488 (4 In 4 Out - 971/9702 SerDes - KU11P) | NI PXIe-1488 (4 In 4 Out - KU11P) | [2023 Q2](#compat-note)    | 0x7AE6     | 1488_4I_4O  |
+
 <a id="compat-note"></a>
 > (\*) Full details on hardware and OS compatibility can be found [here](https://www.ni.com/en-us/support/documentation/compatibility/21/ni-hardware-and-operating-system-compatibility.html) on ni.com.
 

--- a/docs/tutorials/gettingstartedexample/gse-acq-basic.md
+++ b/docs/tutorials/gettingstartedexample/gse-acq-basic.md
@@ -67,6 +67,8 @@ A supported interface module and camera on a PXI system running Windows.
     | PXIe-1486 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1486_4\_In_4\_Out_Acq_Tap.lvbitx |
     | PXIe-1487 (8 In)       | FPGA Bitfiles\\PXIe_1487_8\_In.lvbitx                |
     | PXIe-1487 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1487_4\_In_4\_Out_Acq_Tap.lvbitx |
+    | PXIe-1488 (8 In)       | FPGA Bitfiles\\PXIe_1488_8\_In.lvbitx                |
+    | PXIe-1488 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1488_4\_In_4\_Out_Acq_Tap.lvbitx |
 
     > The values on the **Resource** tab of **Configuration Settings** are now similar to the figure below.
 

--- a/docs/tutorials/gettingstartedexample/gse-gen-basic.md
+++ b/docs/tutorials/gettingstartedexample/gse-gen-basic.md
@@ -25,6 +25,8 @@ A supported interface module on a PXI system running a compatible Windows versio
 | PXIe-1486 (4 In 4 Out - 953/954 SerDes)     |
 | PXIe-1487 (8 Out - 9295A Serializer)        |
 | PXIe-1487 (4 In 4 Out - 9295A/9296A SerDes) |
+| PXIe-1488 (8 Out - 971 Serializer)          |
+| PXIe-1488 (4 In 4 Out - 971/9702 SerDes)    |
 
 ## Initial Hardware Setup
 
@@ -94,9 +96,11 @@ Complete this part of the tutorial to generate images, which will be stored to t
     | **Interface Module**   | **Bitfile**                                          |
     |------------------------|------------------------------------------------------|
     | PXIe-1486 (8 Out)       | FPGA Bitfiles\\PXIe_1486_8\_Out.lvbitx              |
-    | PXIe-1486 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1486_4\_In_4\_Out_Gen.lvbitx |
+    | PXIe-1486 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1486_4\_In_4\_Out_Gen.lvbitx     |
     | PXIe-1487 (8 Out)       | FPGA Bitfiles\\PXIe_1487_8\_Out.lvbitx              |
-    | PXIe-1487 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1487_4\_In_4\_Out_Gen.lvbitx |
+    | PXIe-1487 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1487_4\_In_4\_Out_Gen.lvbitx     |
+    | PXIe-1488 (8 Out)       | FPGA Bitfiles\\PXIe_1488_8\_Out.lvbitx              |
+    | PXIe-1488 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1488_4\_In_4\_Out_Gen.lvbitx     |
 
     > The values on the **Resource** tab of **Configuration Settings** are now similar to the figure below.
 

--- a/docs/tutorials/gettingstartedexample/gse-tap-basic.md
+++ b/docs/tutorials/gettingstartedexample/gse-tap-basic.md
@@ -78,6 +78,7 @@ A supported interface module that includes both serial input and serial output c
     |------------------------|------------------------------------------------------|
     | PXIe-1486 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1486_4\_In_4\_Out_Acq_Tap.lvbitx |
     | PXIe-1487 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1487_4\_In_4\_Out_Acq_Tap.lvbitx |
+    | PXIe-1488 (4 In 4 Out) | FPGA Bitfiles\\PXIe_1488_4\_In_4\_Out_Acq_Tap.lvbitx |
 
     > The values on the **Resource** tab of **Configuration Settings** are now similar to the figure below.
 


### PR DESCRIPTION
First pass to add 1488 details to existing documentation.

Can be reviewed live here: https://hernstrom.github.io//automotive-camera-module-reference/