### PR TITLE
Add flexrio version info to wait for safe to disconnect api documentation

### DIFF
--- a/docs/reference/hardware/powerovercoax.md
+++ b/docs/reference/hardware/powerovercoax.md
@@ -44,6 +44,8 @@ The **Timeout (ms)** input parameter specifies a time limit in milliseconds to w
 
 > See the [Setting the Timeout](#setting-the-timeout) section for help in determining timeout values.
 
+*New in version NI-FlexRIO 24Q1*
+
 ### LabVIEW Block Diagram Example
 The block diagram below provides an example of a production test sequence with the **Wait for PoC Safe to Disconnect** function included.
 


### PR DESCRIPTION
### What does this Pull Request accomplish?
Inform user of the NI-FlexRIO version that has the new function.
![image](https://github.com/ni/automotive-camera-module-reference/assets/17813788/87548acd-265d-4775-9651-ecc0c0577b8e)


### Why should this Pull Request be merged?
N/A

### What testing has been done?
N/A
